### PR TITLE
칼랜더 api 업데이트 다만 (DB로 임의로 넣으면 create_at가 겹쳐서 감정 그래프가 여러개가 보임. 실사용은 문제 없음)

### DIFF
--- a/src/pages/Calendar.js
+++ b/src/pages/Calendar.js
@@ -457,33 +457,45 @@ const CalendarPage = () => {
                         일주일의 나의 감정
                     </div>
                     <div className={styles["chart-bars"]}>
-                      {emotionData.map((e, idx) => {
-                        // 날짜 객체 생성
-                        const date = new Date(e.created_at);
-                        const dayIdx = date.getDay(); // 0(일)~6(토)
-                        const dayName = DAYS[dayIdx];
-                        const dayNum = String(date.getDate()).padStart(2, "0");
-
-                        // 감정 필드(joy, sadness...) 뽑기
+                      {Array.from({ length: 7 }).map((_, idx) => {
+                        const dateStr = (() => {
+                          const today = new Date();
+                          const d = new Date(today);
+                          d.setDate(today.getDate() - 6 + idx);
+                          return d;
+                        })();
+                        const dayName = DAYS[dateStr.getDay()];
+                        const dayNum = String(dateStr.getDate()).padStart(2, "0");
+                        const emotion = emotionData.find(e => {
+                          if (!e.created_at) return false;
+                          const eDate = new Date(e.created_at);
+                          return (
+                            eDate.getFullYear() === dateStr.getFullYear() &&
+                            eDate.getMonth() === dateStr.getMonth() &&
+                            eDate.getDate() === dateStr.getDate()
+                          );
+                        });
                         let offset = 0;
                         return (
-                          <div key={e.created_at || idx} className={styles["chart-column"]}>
-                            {Object.entries(EMOTION_COLORS).map(([emo, color]) => {
-                              const val = e[emo] ?? 0;
-                              const bar = (
-                                <div
-                                  key={emo}
-                                  className={styles.bar}
-                                  style={{
-                                    backgroundColor: color,
-                                    height: `${val}px`,
-                                    bottom: `${offset}px`,
-                                  }}
-                                />
-                              );
-                              offset += val;
-                              return bar;
-                            })}
+                          <div key={dayName + dayNum} className={styles["chart-column"]}>
+                            {emotion
+                              ? Object.entries(EMOTION_COLORS).map(([emo, color]) => {
+                                  const val = emotion[emo] ?? 0;
+                                  const bar = (
+                                    <div
+                                      key={emo}
+                                      className={styles.bar}
+                                      style={{
+                                        backgroundColor: color,
+                                        height: `${val}px`,
+                                        bottom: `${offset}px`,
+                                      }}
+                                    />
+                                  );
+                                  offset += val;
+                                  return bar;
+                                })
+                              : null}
                             <div className={styles["day-label"]}>
                               <div>{dayName}</div>
                               <div className={styles["day-date"]}>{dayNum}일</div>

--- a/src/pages/Calendar.js
+++ b/src/pages/Calendar.js
@@ -37,7 +37,7 @@ const EMOTION_KR = {
     confusion: "당황",
     boredom: "따분",
 };
-const DAYS = ["월", "화", "수", "목", "금", "토", "일"];
+const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
 /* ───────────────────────── 유틸 ───────────────────────── */
 const getTodayString = () => {
@@ -350,7 +350,8 @@ const CalendarPage = () => {
     const firstDay = new Date(year, month, 1).getDay();
     const lastDate = new Date(year, month + 1, 0).getDate();
     const calendarRows = [];
-    let day = 1 - (firstDay === 0 ? 6 : firstDay - 1);
+    const todayStr = getTodayString();
+    let day = 1 - firstDay;
     for (let i = 0; i < 6; i++) {
         const row = [];
         let hasValid = false;
@@ -360,10 +361,13 @@ const CalendarPage = () => {
                 2,
                 "0"
             )}-${String(day).padStart(2, "0")}`;
+            const isToday = dateStr === todayStr;
             row.push(
                 <td key={j}>
                     {valid ? (
-                        <button onClick={() => openPopup(dateStr)}>
+                        <button onClick={() => openPopup(dateStr)}
+                        className={isToday ? styles.today : undefined}
+                        >
                             {day}
                         </button>
                     ) : (

--- a/src/pages/Calendar.module.css
+++ b/src/pages/Calendar.module.css
@@ -216,6 +216,25 @@
   word-break: keep-all;
 }
 
+/* Calendar.module.css */
+
+.today {
+  border: 2px solid #ff4c4c;
+  border-radius: 50% !important;
+  color: #000000 !important;
+  font-weight: bold !important;
+  background: #d63232 !important;
+  width: 2.2em !important;
+  height: 2.2em !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin: 0 auto !important;
+  padding: 0 !important;
+  box-sizing: border-box !important;
+}
+
+
 .legend {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/RecordSummary.js
+++ b/src/pages/RecordSummary.js
@@ -87,7 +87,7 @@ const RecordSummary = () => {
 
     setIsLoading(true);
     try {
-      await axios.post(
+      await axios.put(
         // "https://ms-fom-backend-hwcudkcfgedgcagj.eastus2-01.azurewebsites.net/api/diary/create/",
         "https://fombackend.azurewebsites.net/api/diary/create",
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 캘린더에서 오늘 날짜가 강조 표시됩니다.

- **버그 수정**
  - 주간 감정 데이터가 한 번의 API 호출로 효율적으로 불러와집니다.
  - 일기 저장 및 삭제 기능의 안정성이 향상되었습니다.

- **UI/UX 개선**
  - 캘린더가 일요일 시작으로 변경되고, 감정 차트가 최근 7일 데이터를 동적으로 표시합니다.
  - 일기 팝업 및 삭제 확인 팝업의 디자인과 상호작용이 개선되었습니다.
  - 마스코트 상담 기능이 캐싱 및 에러 처리로 더욱 안정적으로 동작합니다.

- **스타일**
  - 오늘 날짜를 위한 새로운 시각적 스타일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->